### PR TITLE
change `print` to `println` in src/watch.jl

### DIFF
--- a/src/watch.jl
+++ b/src/watch.jl
@@ -37,7 +37,7 @@ function watch(callback::Function, dir::String; targets=ARGS, sources::Union{Vec
         errmsg = fetch(errstream)
         if !isempty(errmsg)
             for line in split(errmsg, '\n')
-                !startswith(line, "WARNING: replacing module test") && print(stderr, line)
+                !startswith(line, "WARNING: replacing module test") && println(stderr, line)
             end
         end
     end


### PR DESCRIPTION
There was an issue with watch.jl, where error messages produced by
Revise.jl would all be printed on the same line without any linebreaks.
For example, different lines of a stacktrace would all be printed
together. Changing `print` -> `println` fixes the issue.