### PR TITLE
correctly pass a String[] instead of Any[] to get_all_files

### DIFF
--- a/src/watch.jl
+++ b/src/watch.jl
@@ -10,7 +10,7 @@ const watched_folders = Dict{String, Tuple{FolderMonitor,Task}}()
 watch the folders.
 """
 function watch(callback::Function, dir::String; targets=ARGS, sources::Union{Vector{Any},Vector{String}}=[])
-    (all_files, start_idx) = get_all_files(dir, [], targets)
+    (all_files, start_idx) = get_all_files(dir, String[], targets)
     for src in sources
         for (root, dirs, files) in walkdir(isfile(src) ? dirname(src) : src)
             for filename in files


### PR DESCRIPTION
After upgrading to  v0.2.14 I ran into
```
ERROR: LoadError: MethodError: no method matching get_all_files(::String, ::Array{Any,1}, ::Array{String,1})
Closest candidates are:
  get_all_files(::String, ::Array{String,1}, ::Array{String,1}) at /home/luuk/.julia/dev/Jive/src/runtests.jl:18
```

which is fixed by this PR.