### PR TITLE
WIP: fix include from tests

### DIFF
--- a/src/runtests.jl
+++ b/src/runtests.jl
@@ -494,7 +494,11 @@ function normal_run(dir::String, tests::Vector{String}, start_idx::Int, stop_on_
         numbering = string(idx, /, length(tests))
         (ts, cumulative_compile_time, elapsed_time) = @jive_testset io numbering subpath verbose "" "" begin
             if isnothing(context)
-                Base.include(Module(), filepath)
+                m = Module()
+                @eval m begin
+                    using Base.MainInclude:include
+                end   
+                Base.include(m, filepath)
             else
                 Base.include(context, filepath)
             end

--- a/test/test/included.jl
+++ b/test/test/included.jl
@@ -1,0 +1,1 @@
+included_function() = 42

--- a/test/test/test_include.jl
+++ b/test/test/test_include.jl
@@ -1,0 +1,3 @@
+include("./included.jl")
+
+included_function()


### PR DESCRIPTION
include from tests doe not fail anymore, but they don't add the created symbols into the test module